### PR TITLE
Fluidlogged API mod compat fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,9 @@ artifacts {
 dependencies {
 	compile 'com.elytradev:mini:0.2-SNAPSHOT'
 	shadow 'com.elytradev:mini:0.2-SNAPSHOT'
+	//fluidlogged api stuff
+	provided 'com.github.jbredwards:Fluidlogged-API:5f90082a9e'
+    	compile 'com.github.jbredwards:Fluidlogged-API:5f90082a9e'
 }
 
 task signShadowJar(type: SignJar, dependsOn: shadowJar) {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ minecraft {
 }
 
 repositories {
-	maven { url = 'https://repo.elytradev.com' }
+	maven { url 'https://repo.elytradev.com' }
 	maven { url 'https://jitpack.io' }
     	ivy {
         	name 'asie dependency mirror'

--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,12 @@ minecraft {
 }
 
 repositories {
-	maven {
-		url = 'https://repo.elytradev.com'
-	}
-    ivy {
-        name 'asie dependency mirror'
-        artifactPattern "http://asie.pl/javadeps/[module]-[revision](-[classifier]).[ext]"
-    }
+	maven { url = 'https://repo.elytradev.com' }
+	maven { url 'https://jitpack.io' }
+    	ivy {
+        	name 'asie dependency mirror'
+        	artifactPattern "http://asie.pl/javadeps/[module]-[revision](-[classifier]).[ext]"
+    	}
 }
 
 dependencies {


### PR DESCRIPTION
The BlockLiquidForged class's getExtendedState has been changed to fix the new vanilla fluid renderer from clashing with the fluidlogged api mod. I would fix this from the end of the fluidlogged api mod, but that would require asm (whereas this one doesn't), so I think the fix makes more sense to come from this end. The issue that informed me about this is linked [here](https://github.com/jbredwards/Fluidlogged-API/issues/8) in case you wanna take a look. If you don't update this mod anymore, sorry to bother, just thought I'd try to help. :)